### PR TITLE
Add a request manager to find unawaited requests

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,8 @@
+import { AddAwaitedRequest } from './request-manager';
+
+Cypress.Commands.overwrite<'wait', 'optional'>('wait', (originalFn, alias, options) => {
+  const optionList = typeof options === 'string' ? [options] : options;
+  AddAwaitedRequest(optionList);
+  return originalFn(alias, options);
+});
+%

--- a/src/endpoint-helper.ts
+++ b/src/endpoint-helper.ts
@@ -1,5 +1,6 @@
 import { GenericStaticResponse, HttpRequestInterceptor } from 'cypress/types/net-stubbing';
 import { AbstractEndpoint } from './endpoint';
+import { AddRequestedUrl } from './request-manager';
 import { RouteConfig } from './routing';
 import Chainable = Cypress.Chainable;
 
@@ -14,6 +15,7 @@ export class EndpointHelper {
   static stub<OUT>(routeConfig: RouteConfig<OUT>): void {
     const { route } = routeConfig;
     const interceptor: HttpRequestInterceptor = (req) => {
+      AddRequestedUrl(routeConfig.name);
       const response: GenericStaticResponse<string, OUT> = {
         body: route.response,
         statusCode: route.status,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@ export * from './endpoint';
 export * from './endpoint-helper';
 export * from './routing';
 export * from './spy-http-client';
+export * from './commands';
+export * from './mocha-override';

--- a/src/mocha-override.ts
+++ b/src/mocha-override.ts
@@ -1,0 +1,9 @@
+import { CheckEmptiedStubRequests, ResetStubbedRequests } from './request-manager';
+
+before(ResetStubbedRequests);
+
+beforeEach(ResetStubbedRequests);
+
+after(CheckEmptiedStubRequests);
+
+afterEach(CheckEmptiedStubRequests);

--- a/src/request-manager.ts
+++ b/src/request-manager.ts
@@ -1,0 +1,56 @@
+let requestAliases: { [key: string]: { awaited: number; requested: number } } = {};
+
+export const ResetStubbedRequests = () => {
+  requestAliases = {};
+};
+
+export const AddRequestedUrl = (alias: string) => {
+  addRequestedUrl(alias);
+};
+
+export const AddAwaitedRequest = (aliases: string[]) => {
+  if (!aliases) {
+    return;
+  }
+  aliases.forEach((alias) => {
+    // Removing @
+    addAwaitedUrl(alias.substring(1));
+  });
+};
+
+export const CheckEmptiedStubRequests = () => {
+  const notAwaited = notAwaitedRequests();
+  // Check that the set is first empty and throw if not because all request previously tested have not been awaited
+  if (notAwaited.length !== 0) {
+    throw `You have not awaited all urls in the previous test. Not awaited requests: ${Array.from(notAwaited).join(
+      ', '
+    )}`;
+  }
+};
+
+function addRequestedUrl(url: string) {
+  if (url in requestAliases) {
+    requestAliases[url].requested++;
+  } else {
+    requestAliases[url] = { requested: 1, awaited: 0 };
+  }
+}
+
+function addAwaitedUrl(url: string) {
+  if (url in requestAliases) {
+    requestAliases[url].awaited++;
+  } else {
+    requestAliases[url] = { requested: 0, awaited: 1 };
+  }
+}
+
+function notAwaitedRequests() {
+  const notAwaited = [];
+  for (const url of Object.keys(requestAliases)) {
+    const urlStats = requestAliases[url];
+    if (urlStats.awaited < urlStats.requested) {
+      notAwaited.push(url);
+    }
+  }
+  return notAwaited;
+}


### PR DESCRIPTION
A lot of the flakiness on cypress tests seems to come from unwaited stubbed requests. 
By adding this manager and forcing testers to explicitly await all requests, this should reduce flakiness. 

In case a tester did not await all requests done during an _it_ test, the test will throw at the end. 

Points of improvement:
- This is a POC, so there are no tests for now
- I am not sure if it is also possible to tests the _before_ statements where requests can also happen
- We could also add a parameter to whitelist a request as _not awaited on purpose_, to allow testing for loading situations (however the expected behavior seems to be waiting for all stubbed requests most of the time)