### PR TITLE
Fixing typescript typing being too generic

### DIFF
--- a/example-app/cypress/integration/example.e2e-spec.ts
+++ b/example-app/cypress/integration/example.e2e-spec.ts
@@ -66,8 +66,8 @@ describe('Main Page (with the library)', () => {
     // Assert
     cy.get('h1').contains('This is my ad set');
     // You might prefer to refer to the fixture directly
-    cy.get('h1').contains(getById.fixture?.adSet?.name);
-    cy.get('h2').contains(getById.fixture?.adSet?.description);
+    if (getById.fixture?.adSet?.name) cy.get('h1').contains(getById.fixture?.adSet?.name);
+    if (getById.fixture?.adSet?.description) cy.get('h2').contains(getById.fixture?.adSet?.description);
   });
 
   it('should handled ad set not found', () => {

--- a/example-app/cypress/tsconfig.json
+++ b/example-app/cypress/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["cypress"],
+    "baseUrl": "./",
+    "paths": {
+      "@app/*": ["../src/app/*"],
+      "@cypress/*": ["*"]
+    },
+    "skipLibCheck": true
+  },
+  "include": ["../node_modules/cypress", "./**/*.ts"]
+}

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build:check-typing": "tsc --noEmit --project tsconfig.spec.json && tsc --noEmit --project ./cypress",
     "watch": "ng build --watch --configuration development",
     "cypress:open": "cypress open"
   },

--- a/example-app/src/app/app.component.ts
+++ b/example-app/src/app/app.component.ts
@@ -15,7 +15,7 @@ function isDefined<T>(arg: T | null | undefined): arg is T {
 @Injectable()
 export class AppComponent {
   constructor(private readonly adSetClient: AdSetsClient) {
-    this.adSet$ = this.adSetClient.getById(12).pipe(
+    this.adSet$ = this.adSetClient.getById(12, 'Ad set name').pipe(
       map((response) => response?.adSet),
       filter(isDefined),
       // Of course this is not how you should handle errors

--- a/example-app/src/client-generated-by-nswag.ts
+++ b/example-app/src/client-generated-by-nswag.ts
@@ -31,7 +31,7 @@ export class AdSetsClient extends GeneratedClient {
         this.baseUrl = baseUrl ? baseUrl : "";
     }
 
-  getById(adSetId: number): Observable<GetAdSetDetailsResponse | null> {
+  getById(adSetId: number, adSetName: string): Observable<GetAdSetDetailsResponse | null> {
     let url_ = this.baseUrl + "/campaign-api/ad-sets/{adSetId}";
     if (adSetId === undefined || adSetId === null)
       throw new Error("The parameter 'adSetId' must be defined.");

--- a/example-app/tsconfig.spec.json
+++ b/example-app/tsconfig.spec.json
@@ -5,6 +5,6 @@
     "outDir": "./out-tsc/spec",
     "types": ["jasmine"]
   },
-  "files": ["src/test.ts", "src/polyfills.ts"],
+  "files": ["src/polyfills.ts"],
   "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,7 +10,9 @@ import { SpyHttpClient } from './spy-http-client';
  */
 export abstract class AbstractClientStub {
   // AbstractEndpoint<never, unknown> needed for endpoints without parameter
-  abstract endpoints: { [endpointName: string]: AbstractEndpoint<unknown, unknown> | AbstractEndpoint<never, unknown> };
+  abstract endpoints: {
+    [endpointName: string]: AbstractEndpoint<unknown[], unknown> | AbstractEndpoint<never, unknown>;
+  };
 
   protected constructor(public name: string) {}
 
@@ -39,8 +41,8 @@ export abstract class ClientStub<C> extends AbstractClientStub {
     this.client = new clientConstructor(this.spyHttpClient as unknown as HttpClient);
   }
 
-  protected createEndpoint<IN, OUT>(
-    actualEndpoint: (...otherParams: IN[]) => Observable<OUT>,
+  protected createEndpoint<IN extends unknown[], OUT>(
+    actualEndpoint: (...otherParams: IN) => Observable<OUT>,
     status: number,
     fixture: OUT,
     headers: Headers = {}

--- a/src/endpoint-helper.ts
+++ b/src/endpoint-helper.ts
@@ -61,7 +61,10 @@ export class EndpointHelper {
    * @param endpoint
    * @param expectedRequest
    */
-  static waitForCallAndCheck<IN>(endpoint: AbstractEndpoint<IN, unknown>, expectedRequest: Partial<IN>): Chainable {
+  static waitForCallAndCheck<IN extends unknown[]>(
+    endpoint: AbstractEndpoint<IN, unknown>,
+    expectedRequest: Partial<IN>
+  ): Chainable {
     return cy
       .wait(endpoint.alias)
       .its('request.body')
@@ -80,7 +83,7 @@ export class EndpointHelper {
    * @param endpoint
    * @param assertion
    */
-  static waitForCallAndAssert<IN>(
+  static waitForCallAndAssert<IN extends unknown[]>(
     endpoint: AbstractEndpoint<IN, unknown>,
     assertion: (requestBody: IN) => boolean
   ): Chainable {


### PR DESCRIPTION
Typing is breaking between version `3.0.0-beta.0` and `2.0.1` surely due to a change in typing in the packages ([it seems to be the only difference between the two versions](https://github.com/criteo/cypress-typed-stubs/compare/2.0.0...2.0.1)). I am still not sure which package update causes this problem (surely `tslib` but no evidence in release note)

Before this change, the typing generated for the parameters of an endpoint like: `(a: number, b: boolean)` were `(number | boolean)[]`, now they are `(a: number, b: boolean)`. You can see the typing difference [difference in this sandbox](https://www.typescriptlang.org/play?ts=4.2.3#code/PTAEHUFMBsGMHsC2lQBd5oBYoCoE8AHSAZVgCcBLA1UABWgEM8BzM+AVwDsATAGiwoBnUENANQAd0gAjQRVSQAUCEmYKsTKGYUAbpGF4OY0BoadYKdJMoL+gzAzIoz3UNEiPOofEVKVqAHSKymAAmkYI7NCuqGqcANag8ABmIjQUXrFOKBJMggBcISGgoAC0oACCbvCwDKgU8JkY7p7ehCTkVDQS2E6gnPCxGcwmZqDSTgzxxWWVoASMFmgYkAAeRJTInN3ymj4d-jSCeNsMq-wuoPaOltigAKoASgAywhK7SbGQZIIz5VWCFzSeCrZagNYbChbHaxUDcCjJZLfSDbExIAgUdxkUBIursJzCFJtXydajBZJcWD1RpofSoADCDGg0AAQgxYPFiMN3ABxFHfdQAHiqawUPGEXHiAwknAA2gBdAB8AApaszpOz4vlQMqAnqGNqKgBKUAAXkV-XYiGk3xNAG9FCUSk5UPivGroBqOQBuUCKAC+wR0jiu3JQptpggZTNZmq5nGYvP5lFgyuVBst1u+-Gk2qjlAT-Fg2uB8BanBN5tAAEYjb7yZTqZk6YzmWyOc8hKg+ZwBbBhSqPV6tTq9QEMxUFZWLZwrTayPbHU6XW7RurNfXA4pg9joF2zZHo23NZ2oz2+2mM7Os2Qc3nUAXmEWS-Ayx4K2aLbXfUA).