### PR TITLE
Set rxjs as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "cypress-typed-stubs",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-typed-stubs",
-      "version": "4.0.0-beta.0",
+      "version": "4.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.21",
-        "rxjs": "^6.6.7",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -33,7 +32,8 @@
       "peerDependencies": {
         "@angular/common": ">= 13",
         "@angular/core": ">= 13",
-        "cypress": ">= 9"
+        "cypress": ">= 9",
+        "rxjs": "^6.6.7 || ^7.4.0"
       }
     },
     "node_modules/@angular/common": {
@@ -3546,6 +3546,7 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -3556,7 +3557,8 @@
     "node_modules/rxjs/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "peer": true
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -6722,6 +6724,7 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "peer": true,
       "requires": {
         "tslib": "^1.9.0"
       },
@@ -6729,7 +6732,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "peer": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-typed-stubs",
-  "version": "4.0.0-beta.0",
+  "version": "4.0.0-beta.1",
   "homepage": "https://github.com/criteo/cypress-typed-stubs",
   "description": "Typed Cypress stubs with automatic URL patterns, based on clients generated with Swagger",
   "keywords": [
@@ -29,13 +29,13 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "rxjs": "^6.6.7",
     "tslib": "^2.3.1"
   },
   "peerDependencies": {
     "@angular/common": ">= 13",
     "@angular/core": ">= 13",
-    "cypress": ">= 9"
+    "cypress": ">= 9",
+    "rxjs": "^6.6.7 || ^7.4.0"
   },
   "devDependencies": {
     "@angular/common": "13.3.12",


### PR DESCRIPTION
Make package compatible with version 6 and 7

We allow consumer to choose their version of RxJS. Same setup as angular 13 core package https://github.com/angular/angular/blob/13.0.0/packages/core/package.json