### PR TITLE
Support numbers in cy.wait

### DIFF
--- a/example-app/cypress/integration/features.e2e-spec.ts
+++ b/example-app/cypress/integration/features.e2e-spec.ts
@@ -1,0 +1,21 @@
+import { EndpointHelper } from '../../../src';
+import { AdSetsStub } from '../support/ad-sets.stub';
+
+describe('Features', () => {
+  const stub = new AdSetsStub().init();
+  const getById = stub.endpoints.getById;
+
+  it('should support cy.wait with a number', () => {
+    cy.wait(3000);
+  });
+
+  it('should FAIL when request is not awaited', () => {
+    EndpointHelper.stub(getById.defaultConfig());
+
+    // Act
+    cy.visit('http://localhost:4200');
+
+    // Assert
+    cy.get('h1').contains('This is my ad set');
+  });
+});

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,7 +1,9 @@
 import { AddAwaitedRequest } from './request-manager';
 
 Cypress.Commands.overwrite<'wait', 'optional'>('wait', (originalFn, alias, options) => {
-  const optionList = typeof options === 'string' ? [options] : options;
-  AddAwaitedRequest(optionList);
+  if (typeof options !== 'number') {
+    const optionList = typeof options === 'string' ? [options] : options;
+    AddAwaitedRequest(optionList);
+  }
   return originalFn(alias, options);
 });


### PR DESCRIPTION
Before this review and after the improvements brought by the v3, `cy.wait(number)` code is not working anymore. 
This change reintroduces support.