### PR TITLE
✨ Allow using a fixture builder function in stubbed endpoints 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,43 @@ export class AdSetsStub extends ClientStub<AdSetsClient> {
 }
 ```
 
+Instead of a fixture, you can provide a fixture builder: it is a function that takes a cypress request object ([CyHttpMessages.IncomingHttpRequest](https://github.com/cypress-io/cypress/blob/develop/packages/net-stubbing/lib/external-types.ts#L166C3-L198C4)) as parameter and returns a fixture.
+It is useful to adapt the fixture depending on the request (for example, request body or query parameters):
+
+```typescript
+export class AdSetsStub extends ClientStub<AdSetsClient> {
+  constructor() {
+    super(AdSetsClient);
+  }
+
+  endpoints = {
+    getById: this.createEndpoint(
+      this.client.getById,
+      200,
+      // No static fixture provided
+      undefined,
+      {},
+      // Fixture builder function -> builds the fixture depending on the request
+      // (here depending on 'language' query parameter).
+      (req) => (req.query['language'] === 'fr-FR' ?
+        {
+          adSet: {
+            name: "Ceci est mon ensemble d'annonce",
+            // ... other properties
+          },
+        } :
+        {
+          adSet: {
+            name: 'This is my ad set',
+            // ... other properties
+          },
+        }
+      )
+    ),
+  };
+}
+```
+
 #### Intercept
 
 These **endpoints** can then be used in any Cypress test for intercept.

--- a/example-app/cypress/fixtures/ad-sets.ts
+++ b/example-app/cypress/fixtures/ad-sets.ts
@@ -1,0 +1,27 @@
+import { AdSetStatus, AudienceType, GetAdSetDetailsResponse } from '../../src/client-generated-by-nswag';
+
+export const adSetEnglish: GetAdSetDetailsResponse = {
+  adSet: {
+    id: 5,
+    partnerId: 5855,
+    name: 'This is my ad set',
+    description: 'The ad set description is here',
+    startDate: new Date('2020-10-20T22:08:46.683'),
+    conflictDetectionToken: 1607941414927,
+    status: AdSetStatus.Draft,
+    audienceType: AudienceType.Custom,
+  },
+};
+
+export const adSetFrench: GetAdSetDetailsResponse = {
+  adSet: {
+    id: 5,
+    partnerId: 5855,
+    name: "Ceci est mon ensemble d'annonce",
+    description: "La description de l'ensemble d'annonce est ici",
+    startDate: new Date('2020-10-20T22:08:46.683'),
+    conflictDetectionToken: 1607941414927,
+    status: AdSetStatus.Draft,
+    audienceType: AudienceType.Custom,
+  },
+};

--- a/example-app/cypress/integration/example.e2e-spec.ts
+++ b/example-app/cypress/integration/example.e2e-spec.ts
@@ -30,7 +30,7 @@ describe('Main Page (without the library)', () => {
     cy.get('h1').contains('This is my ad set');
   });
 
-  it('should handled ad set not found', () => {
+  it('should handle ad set not found', () => {
     // Prepare
     cy.intercept('GET', /.*\/campaign-api\/ad-sets\/.*/, {
       statusCode: 404,
@@ -70,7 +70,7 @@ describe('Main Page (with the library)', () => {
     if (getById.fixture?.adSet?.description) cy.get('h2').contains(getById.fixture?.adSet?.description);
   });
 
-  it('should handled ad set not found', () => {
+  it('should handle ad set not found', () => {
     // Prepare
     EndpointHelper.stub(
       getById

--- a/example-app/cypress/integration/features.e2e-spec.ts
+++ b/example-app/cypress/integration/features.e2e-spec.ts
@@ -4,12 +4,14 @@ import { AdSetsStub } from '../support/ad-sets.stub';
 describe('Features', () => {
   const stub = new AdSetsStub().init();
   const getById = stub.endpoints.getById;
+  const getByIdWithFixtureBuilder = stub.endpoints.getByIdWithFixtureBuilder;
 
   it('should support cy.wait with a number', () => {
     cy.wait(3000);
   });
 
   it('should FAIL when request is not awaited', () => {
+    // Prepare
     EndpointHelper.stub(getById.defaultConfig());
 
     // Act
@@ -17,5 +19,31 @@ describe('Features', () => {
 
     // Assert
     cy.get('h1').contains('This is my ad set');
+  });
+
+  it('should handle fixture builder', () => {
+    // Prepare
+    // Get the default config with fixture builder
+    EndpointHelper.stub(getByIdWithFixtureBuilder.defaultConfig());
+
+    // Visit page
+    cy.visit('http://localhost:4200');
+    // Make sure the ad set is loaded
+    cy.wait(getByIdWithFixtureBuilder.alias);
+
+    // Assert ad set was loaded with english text
+    cy.get('h1').contains('This is my ad set');
+    cy.get('select').should('have.value', 'en-US');
+    cy.get('select option:selected').should('have.text', 'English');
+
+    // Change language selection to french
+    cy.get('select').select('Français');
+    // Make sure the ad set is loaded
+    cy.wait(getByIdWithFixtureBuilder.alias);
+
+    // Assert ad set was loaded with french text
+    cy.get('h1').contains("Ceci est mon ensemble d'annonce");
+    cy.get('select').should('have.value', 'fr-FR');
+    cy.get('select option:selected').should('have.text', 'Français');
   });
 });

--- a/example-app/cypress/support/ad-sets.stub.ts
+++ b/example-app/cypress/support/ad-sets.stub.ts
@@ -1,5 +1,6 @@
 import { ClientStub } from '../../../src';
-import { AdSetsClient, AdSetStatus, AudienceType } from '../../src/client-generated-by-nswag';
+import { AdSetsClient } from '../../src/client-generated-by-nswag';
+import { adSetEnglish, adSetFrench } from '@cypress/fixtures/ad-sets';
 
 export class AdSetsStub extends ClientStub<AdSetsClient> {
   constructor() {
@@ -10,19 +11,17 @@ export class AdSetsStub extends ClientStub<AdSetsClient> {
     getById: this.createEndpoint(
       this.client.getById,
       200,
-      // Everything is typed
-      {
-        adSet: {
-          id: 5,
-          partnerId: 5855,
-          name: 'This is my ad set',
-          description: 'The ad set description is here',
-          startDate: new Date('2020-10-20T22:08:46.683'),
-          conflictDetectionToken: 1607941414927,
-          status: AdSetStatus.Draft,
-          audienceType: AudienceType.Custom,
-        },
-      }
+      adSetEnglish // fixture is typed
+    ),
+    getByIdWithFixtureBuilder: this.createEndpoint(
+      this.client.getById,
+      200,
+      // No static fixture provided
+      undefined,
+      {},
+      // Fixture builder function -> builds the fixture depending on the request
+      // (here depending on 'language' query parameter).
+      (req) => (req.query['language'] === 'fr-FR' ? adSetFrench : adSetEnglish)
     ),
   };
 }

--- a/example-app/src/app/app.component.html
+++ b/example-app/src/app/app.component.html
@@ -1,4 +1,9 @@
 <ng-container *ngIf="adSet$ | async as adSet">
   <h1>{{adSet.name}}</h1>
   <h2>{{adSet.description}}</h2>
+
+  <select [(ngModel)]="selectedLanguageCode" (change)="onLanguageSelected()">
+    <option *ngFor="let language of languages" [value]="language.code">{{ language.name }}</option>
+  </select>
+
 </ng-container>

--- a/example-app/src/app/app.component.ts
+++ b/example-app/src/app/app.component.ts
@@ -7,6 +7,11 @@ function isDefined<T>(arg: T | null | undefined): arg is T {
   return arg !== null && arg !== undefined;
 }
 
+interface Language {
+  code: string;
+  name: string;
+}
+
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
@@ -14,8 +19,21 @@ function isDefined<T>(arg: T | null | undefined): arg is T {
 })
 @Injectable()
 export class AppComponent {
+  languages: Language[] = [
+    { code: 'en-US', name: 'English' },
+    { code: 'fr-FR', name: 'Français' },
+  ];
+
+  onLanguageSelected() {
+    this.adSet$ = this.fetchAdSet();
+  }
+
   constructor(private readonly adSetClient: AdSetsClient) {
-    this.adSet$ = this.adSetClient.getById(12, 'Ad set name').pipe(
+    this.adSet$ = this.fetchAdSet();
+  }
+
+  private fetchAdSet(): Observable<AdSetDetails> {
+    return this.adSetClient.getById(12, this.selectedLanguageCode).pipe(
       map((response) => response?.adSet),
       filter(isDefined),
       // Of course this is not how you should handle errors
@@ -26,4 +44,5 @@ export class AppComponent {
   }
 
   adSet$: Observable<AdSetDetails>;
+  selectedLanguageCode: string = this.languages[0].code;
 }

--- a/example-app/src/app/app.module.ts
+++ b/example-app/src/app/app.module.ts
@@ -3,10 +3,11 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, AppRoutingModule, HttpClientModule],
+  imports: [BrowserModule, AppRoutingModule, HttpClientModule, FormsModule],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/example-app/src/client-generated-by-nswag.ts
+++ b/example-app/src/client-generated-by-nswag.ts
@@ -31,11 +31,13 @@ export class AdSetsClient extends GeneratedClient {
         this.baseUrl = baseUrl ? baseUrl : "";
     }
 
-  getById(adSetId: number, adSetName: string): Observable<GetAdSetDetailsResponse | null> {
-    let url_ = this.baseUrl + "/campaign-api/ad-sets/{adSetId}";
+  getById(adSetId: number, language?: string | null | undefined): Observable<GetAdSetDetailsResponse | null> {
+    let url_ = this.baseUrl + "/campaign-api/ad-sets/{adSetId}?";
     if (adSetId === undefined || adSetId === null)
       throw new Error("The parameter 'adSetId' must be defined.");
     url_ = url_.replace("{adSetId}", encodeURIComponent("" + adSetId));
+    if (language !== undefined && language !== null)
+      url_ += "language=" + encodeURIComponent("" + language) + "&";
     url_ = url_.replace(/[?&]$/, "");
 
     let options_ : any = {
@@ -66,7 +68,7 @@ export class AdSetsClient extends GeneratedClient {
       response instanceof HttpResponse ? response.body :
         (<any>response).error instanceof Blob ? (<any>response).error : undefined;
 
-    let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }};
+    let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
     if (status === 200) {
       return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
         let result200: any = null;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import { HttpClient } from '@angular/common/http';
+import { CyHttpMessages } from 'cypress/types/net-stubbing';
 import { Observable } from 'rxjs';
 import { AbstractEndpoint, Endpoint } from './endpoint';
 import { Headers, RouteConfig } from './routing';
@@ -45,8 +46,18 @@ export abstract class ClientStub<C> extends AbstractClientStub {
     actualEndpoint: (...otherParams: IN) => Observable<OUT>,
     status: number,
     fixture: OUT,
-    headers: Headers = {}
+    headers: Headers = {},
+    fixtureBuilder?: (req: CyHttpMessages.IncomingHttpRequest) => OUT
   ): Endpoint<C, IN, OUT> {
-    return new Endpoint(this.spyHttpClient, this.client, actualEndpoint, this.name, status, fixture, headers);
+    return new Endpoint(
+      this.spyHttpClient,
+      this.client,
+      actualEndpoint,
+      this.name,
+      status,
+      fixture,
+      headers,
+      fixtureBuilder
+    );
   }
 }

--- a/src/endpoint-helper.ts
+++ b/src/endpoint-helper.ts
@@ -17,7 +17,7 @@ export class EndpointHelper {
     const interceptor: HttpRequestInterceptor = (req) => {
       AddRequestedUrl(routeConfig.name);
       const response: GenericStaticResponse<string, OUT> = {
-        body: route.response,
+        body: route.responseBuilder != undefined ? route.responseBuilder(req) : route.response,
         statusCode: route.status,
         headers: {
           ...route.headers,

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,3 +1,4 @@
+import { CyHttpMessages } from 'cypress/types/net-stubbing';
 import { cloneDeep } from 'lodash';
 import { Observable } from 'rxjs';
 import { Headers, Method, RouteConfig } from './routing';
@@ -67,7 +68,8 @@ export class Endpoint<C, IN extends unknown[], OUT> extends AbstractEndpoint<IN,
     parentName: string,
     public statusCode: number,
     public fixture: OUT,
-    headers: Headers = {}
+    headers: Headers = {},
+    public fixtureBuilder?: (req: CyHttpMessages.IncomingHttpRequest) => OUT
   ) {
     super(parentName, headers);
   }
@@ -117,7 +119,8 @@ export class Endpoint<C, IN extends unknown[], OUT> extends AbstractEndpoint<IN,
       // in the sense each call to defaultConfig always return the original fixture,
       // not one that has been modified by a previous call (if it were using the same reference)
       cloneDeep(this.fixture),
-      this.headers
+      this.headers,
+      this.fixtureBuilder
     );
   }
 }
@@ -136,6 +139,8 @@ export class ManualEndpoint<IN extends unknown[], OUT> extends AbstractEndpoint<
 
   fixture: OUT;
 
+  fixtureBuilder?: (req: CyHttpMessages.IncomingHttpRequest) => OUT;
+
   constructor(
     parentName: string,
     method: Method,
@@ -143,7 +148,8 @@ export class ManualEndpoint<IN extends unknown[], OUT> extends AbstractEndpoint<
     originalUrlForSmokeJS: string,
     statusCode: number,
     fixture: OUT,
-    headers: Headers = {}
+    headers: Headers = {},
+    fixtureBuilder?: (req: CyHttpMessages.IncomingHttpRequest) => OUT
   ) {
     super(parentName, headers);
     this.method = method;
@@ -151,6 +157,7 @@ export class ManualEndpoint<IN extends unknown[], OUT> extends AbstractEndpoint<
     this.originalUrlForSmokeJS = originalUrlForSmokeJS;
     this.statusCode = statusCode;
     this.fixture = fixture;
+    this.fixtureBuilder = fixtureBuilder;
   }
 
   defaultConfig(): RouteConfig<OUT> {
@@ -164,7 +171,8 @@ export class ManualEndpoint<IN extends unknown[], OUT> extends AbstractEndpoint<
       // in the sense each call to defaultConfig always return the original fixture,
       // not one that has been modified by a previous call (if it were using the same reference)
       cloneDeep(this.fixture),
-      this.headers
+      this.headers,
+      this.fixtureBuilder
     );
   }
 }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,3 +1,4 @@
+import { CyHttpMessages } from 'cypress/types/net-stubbing';
 import { cloneDeep } from 'lodash';
 
 /**
@@ -64,6 +65,7 @@ export interface RouteWithOriginalUrl extends Route {
  */
 export interface StubbedRoute<OUT> extends Route {
   response: OUT;
+  responseBuilder?: (req: CyHttpMessages.IncomingHttpRequest) => OUT;
   status: number;
   onResponse?: (body: unknown) => void;
   headers?: Headers;
@@ -78,7 +80,8 @@ export class RouteConfig<OUT> {
     public _originalUrlForSmokeJS: string,
     private status: number,
     private _fixture: OUT,
-    private headers: Headers = {}
+    private headers: Headers = {},
+    private readonly _fixtureBuilder?: (req: CyHttpMessages.IncomingHttpRequest) => OUT
   ) {}
 
   get route(): StubbedRoute<OUT> {
@@ -92,6 +95,7 @@ export class RouteConfig<OUT> {
       status: this.status,
       headers: this.headers,
       response: fixture,
+      responseBuilder: this._fixtureBuilder,
       onResponse: (body: unknown) => {
         const logRequest = (parsedBody: unknown) => {
           // eslint-disable-next-line no-console
@@ -140,6 +144,13 @@ export class RouteConfig<OUT> {
    */
   get fixture(): OUT {
     return cloneDeep(this._fixture);
+  }
+
+  /**
+   * Return the fixture builder
+   */
+  get fixtureBuilder(): undefined | ((req: CyHttpMessages.IncomingHttpRequest) => OUT) {
+    return this._fixtureBuilder;
   }
 
   /**


### PR DESCRIPTION
When stubbing an endpoint, we can now provide a `fixtureBuilder` function.
The function takes the HTTP request as parameter, so that we can return a parametrized response (for example based on a query parameter or on the payload's content).

Example app and its tests have been updated.

Documentation has been updated.