### PR TITLE
✨ Allow using a fixture builder function in stubbed endpoints

### DIFF
--- a/example-app/cypress/fixtures/ad-sets.ts
+++ b/example-app/cypress/fixtures/ad-sets.ts
@@ -1,0 +1,27 @@
+import { AdSetStatus, AudienceType, GetAdSetDetailsResponse } from '../../src/client-generated-by-nswag';
+
+export const adSetEnglish: GetAdSetDetailsResponse = {
+  adSet: {
+    id: 5,
+    partnerId: 5855,
+    name: 'This is my ad set',
+    description: 'The ad set description is here',
+    startDate: new Date('2020-10-20T22:08:46.683'),
+    conflictDetectionToken: 1607941414927,
+    status: AdSetStatus.Draft,
+    audienceType: AudienceType.Custom,
+  },
+};
+
+export const adSetFrench: GetAdSetDetailsResponse = {
+  adSet: {
+    id: 5,
+    partnerId: 5855,
+    name: "Ceci est mon ensemble d'annonce",
+    description: "La description de l'ensemble d'annonce est ici",
+    startDate: new Date('2020-10-20T22:08:46.683'),
+    conflictDetectionToken: 1607941414927,
+    status: AdSetStatus.Draft,
+    audienceType: AudienceType.Custom,
+  },
+};

--- a/example-app/cypress/integration/example.e2e-spec.ts
+++ b/example-app/cypress/integration/example.e2e-spec.ts
@@ -30,7 +30,7 @@ describe('Main Page (without the library)', () => {
     cy.get('h1').contains('This is my ad set');
   });
 
-  it('should handled ad set not found', () => {
+  it('should handle ad set not found', () => {
     // Prepare
     cy.intercept('GET', /.*\/campaign-api\/ad-sets\/.*/, {
       statusCode: 404,
@@ -70,7 +70,7 @@ describe('Main Page (with the library)', () => {
     if (getById.fixture?.adSet?.description) cy.get('h2').contains(getById.fixture?.adSet?.description);
   });
 
-  it('should handled ad set not found', () => {
+  it('should handle ad set not found', () => {
     // Prepare
     EndpointHelper.stub(
       getById

--- a/example-app/cypress/integration/features.e2e-spec.ts
+++ b/example-app/cypress/integration/features.e2e-spec.ts
@@ -1,15 +1,114 @@
 import { EndpointHelper } from '../../../src';
 import { AdSetsStub } from '../support/ad-sets.stub';
+import {AdSetStatus, AudienceType} from "../../src/client-generated-by-nswag";
 
 describe('Features', () => {
   const stub = new AdSetsStub().init();
   const getById = stub.endpoints.getById;
+  const getByIdWithFixtureBuilder = stub.endpoints.getByIdWithFixtureBuilder;
 
   it('should support cy.wait with a number', () => {
     cy.wait(3000);
   });
 
+  it('should handle fixture builder', () => {
+    // Prepare
+    // Get the default config with fixture builder
+    EndpointHelper.stub(getByIdWithFixtureBuilder.defaultConfig());
+
+    // Visit page
+    cy.visit('http://localhost:4200');
+    // Make sure the ad set is loaded
+    cy.wait(getByIdWithFixtureBuilder.alias);
+
+    // Assert ad set was loaded with english text
+    cy.get('h1').contains('This is my ad set');
+    cy.get('select').should('have.value', 'en-US');
+    cy.get('select option:selected').should('have.text', 'English');
+
+    // Change language selection to french
+    cy.get('select').select('Français');
+    // Make sure the ad set is loaded
+    cy.wait(getByIdWithFixtureBuilder.alias);
+
+    // Assert ad set was loaded with french text
+    cy.get('h1').contains("Ceci est mon ensemble d'annonce");
+    cy.get('select').should('have.value', 'fr-FR');
+    cy.get('select option:selected').should('have.text', 'Français');
+  });
+
+  it('should override fixture returned by fixture builder', () => {
+    // Prepare
+    // Get the default config with fixture builder and override it
+    EndpointHelper.stub(getByIdWithFixtureBuilder.defaultConfig().withOverride({
+      adSet: {
+        id: 5,
+        name: 'Ceci est mon ensemble d\'annonce modifié',
+        conflictDetectionToken: 1607941414927,
+        status: AdSetStatus.Live,
+        audienceType: AudienceType.Similar,
+      }
+    }));
+
+    // Visit page
+    cy.visit('http://localhost:4200');
+    // Make sure the ad set is loaded
+    cy.wait(getByIdWithFixtureBuilder.alias);
+
+    // Assert ad set was loaded with english text
+    cy.log('Fixture returned for English parameter has been overridden)');
+    cy.get('h1').contains("Ceci est mon ensemble d'annonce modifié");
+    cy.get('select').should('have.value', 'en-US');
+    cy.get('select option:selected').should('have.text', 'English');
+
+    // Change language selection to french
+    cy.get('select').select('Français');
+    // Make sure the ad set is loaded
+    cy.wait(getByIdWithFixtureBuilder.alias);
+
+    // Assert ad set was loaded with french text
+    cy.log('Fixture returned for French parameter has been overridden)');
+    cy.get('h1').contains("Ceci est mon ensemble d'annonce modifié");
+    cy.get('select').should('have.value', 'fr-FR');
+    cy.get('select option:selected').should('have.text', 'Français');
+  });
+
+  it('should map fixture returned by fixture builder', () => {
+    // Prepare
+    // Get the default config with fixture builder
+    EndpointHelper.stub(getByIdWithFixtureBuilder.defaultConfig().mappingFixture((fixture) => {
+      if(fixture?.adSet?.name !== undefined)
+      {
+        fixture.adSet.name = fixture.adSet.name.toUpperCase();
+      }
+      return fixture;
+    }));
+
+    // Visit page
+    cy.visit('http://localhost:4200');
+    // Make sure the ad set is loaded
+    cy.wait(getByIdWithFixtureBuilder.alias);
+
+    // Assert ad set was loaded with english text
+    cy.log('Fixture returned for English parameter has its name capitalized (changed by mapper)');
+    cy.get('h1').contains('THIS IS MY AD SET');
+    cy.get('select').should('have.value', 'en-US');
+    cy.get('select option:selected').should('have.text', 'English');
+
+    // Change language selection to french
+    cy.get('select').select('Français');
+    // Make sure the ad set is loaded
+    cy.wait(getByIdWithFixtureBuilder.alias);
+
+    // Assert ad set was loaded with french text
+    cy.log('Fixture returned for French parameter has its name capitalized (changed by mapper)');
+    cy.get('h1').contains("CECI EST MON ENSEMBLE D'ANNONCE");
+    cy.get('select').should('have.value', 'fr-FR');
+    cy.get('select option:selected').should('have.text', 'Français');
+  });
+
   it('should FAIL when request is not awaited', () => {
+    // Prepare
     EndpointHelper.stub(getById.defaultConfig());
 
     // Act

--- a/example-app/cypress/support/ad-sets.stub.ts
+++ b/example-app/cypress/support/ad-sets.stub.ts
@@ -1,5 +1,6 @@
 import { ClientStub } from '../../../src';
-import { AdSetsClient, AdSetStatus, AudienceType } from '../../src/client-generated-by-nswag';
+import { AdSetsClient } from '../../src/client-generated-by-nswag';
+import { adSetEnglish, adSetFrench } from '@cypress/fixtures/ad-sets';
 
 export class AdSetsStub extends ClientStub<AdSetsClient> {
   constructor() {
@@ -10,19 +11,15 @@ export class AdSetsStub extends ClientStub<AdSetsClient> {
     getById: this.createEndpoint(
       this.client.getById,
       200,
-      // Everything is typed
-      {
-        adSet: {
-          id: 5,
-          partnerId: 5855,
-          name: 'This is my ad set',
-          description: 'The ad set description is here',
-          startDate: new Date('2020-10-20T22:08:46.683'),
-          conflictDetectionToken: 1607941414927,
-          status: AdSetStatus.Draft,
-          audienceType: AudienceType.Custom,
-        },
-      }
+      // Fixture object is typed
+      adSetEnglish
+    ),
+    getByIdWithFixtureBuilder: this.createEndpoint(
+      this.client.getById,
+      200,
+      // Fixture builder function -> builds the fixture depending on the request
+      // (here depending on 'language' query parameter). The function is typed.
+      (req) => (req.query['language'] === 'fr-FR' ? adSetFrench : adSetEnglish)
     ),
   };
 }

--- a/example-app/src/app/app.component.html
+++ b/example-app/src/app/app.component.html
@@ -1,4 +1,8 @@
 <ng-container *ngIf="adSet$ | async as adSet">
   <h1>{{adSet.name}}</h1>
   <h2>{{adSet.description}}</h2>
+
+  <select [(ngModel)]="selectedLanguageCode" (change)="onLanguageSelected()">
+    <option *ngFor="let language of languages" [value]="language.code">{{ language.name }}</option>
+  </select>
 </ng-container>

--- a/example-app/src/app/app.component.ts
+++ b/example-app/src/app/app.component.ts
@@ -7,6 +7,11 @@ function isDefined<T>(arg: T | null | undefined): arg is T {
   return arg !== null && arg !== undefined;
 }
 
+interface Language {
+  code: string;
+  name: string;
+}
+
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
@@ -14,8 +19,21 @@ function isDefined<T>(arg: T | null | undefined): arg is T {
 })
 @Injectable()
 export class AppComponent {
+  languages: Language[] = [
+    { code: 'en-US', name: 'English' },
+    { code: 'fr-FR', name: 'Français' },
+  ];
+
+  onLanguageSelected() {
+    this.adSet$ = this.fetchAdSet();
+  }
+
   constructor(private readonly adSetClient: AdSetsClient) {
-    this.adSet$ = this.adSetClient.getById(12, 'Ad set name').pipe(
+    this.adSet$ = this.fetchAdSet();
+  }
+
+  private fetchAdSet(): Observable<AdSetDetails> {
+    return this.adSetClient.getById(12, this.selectedLanguageCode).pipe(
       map((response) => response?.adSet),
       filter(isDefined),
       // Of course this is not how you should handle errors
@@ -26,4 +44,5 @@ export class AppComponent {
   }
 
   adSet$: Observable<AdSetDetails>;
+  selectedLanguageCode: string = this.languages[0].code;
 }

--- a/example-app/src/app/app.module.ts
+++ b/example-app/src/app/app.module.ts
@@ -3,10 +3,11 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, AppRoutingModule, HttpClientModule],
+  imports: [BrowserModule, AppRoutingModule, HttpClientModule, FormsModule],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/example-app/src/client-generated-by-nswag.ts
+++ b/example-app/src/client-generated-by-nswag.ts
@@ -31,11 +31,13 @@ export class AdSetsClient extends GeneratedClient {
         this.baseUrl = baseUrl ? baseUrl : "";
     }
 
-  getById(adSetId: number, adSetName: string): Observable<GetAdSetDetailsResponse | null> {
-    let url_ = this.baseUrl + "/campaign-api/ad-sets/{adSetId}";
+  getById(adSetId: number, language?: string | null | undefined): Observable<GetAdSetDetailsResponse | null> {
+    let url_ = this.baseUrl + "/campaign-api/ad-sets/{adSetId}?";
     if (adSetId === undefined || adSetId === null)
       throw new Error("The parameter 'adSetId' must be defined.");
     url_ = url_.replace("{adSetId}", encodeURIComponent("" + adSetId));
+    if (language !== undefined && language !== null)
+      url_ += "language=" + encodeURIComponent("" + language) + "&";
     url_ = url_.replace(/[?&]$/, "");
 
     let options_ : any = {
@@ -66,7 +68,7 @@ export class AdSetsClient extends GeneratedClient {
       response instanceof HttpResponse ? response.body :
         (<any>response).error instanceof Blob ? (<any>response).error : undefined;
 
-    let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }};
+    let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
     if (status === 200) {
       return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
         let result200: any = null;

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs';
 import { AbstractEndpoint, Endpoint } from './endpoint';
 import { Headers, RouteConfig } from './routing';
 import { SpyHttpClient } from './spy-http-client';
+import { CyHttpMessages } from 'cypress/types/net-stubbing';
 
 /**
  * A client with a list of endpoints.
@@ -44,9 +45,9 @@ export abstract class ClientStub<C> extends AbstractClientStub {
   protected createEndpoint<IN extends unknown[], OUT>(
     actualEndpoint: (...otherParams: IN) => Observable<OUT>,
     status: number,
-    fixture: OUT,
+    fixtureOrFixtureBuilder: OUT | ((req: CyHttpMessages.IncomingHttpRequest) => OUT),
     headers: Headers = {}
   ): Endpoint<C, IN, OUT> {
-    return new Endpoint(this.spyHttpClient, this.client, actualEndpoint, this.name, status, fixture, headers);
+    return new Endpoint(this.spyHttpClient, this.client, actualEndpoint, this.name, status, fixtureOrFixtureBuilder, headers);
   }
 }

--- a/src/endpoint-helper.ts
+++ b/src/endpoint-helper.ts
@@ -16,8 +16,9 @@ export class EndpointHelper {
     const { route } = routeConfig;
     const interceptor: HttpRequestInterceptor = (req) => {
       AddRequestedUrl(routeConfig.name);
+      const body = route.responseOrResponseBuilder instanceof Function ? route.responseOrResponseBuilder(req) : route.responseOrResponseBuilder;
       const response: GenericStaticResponse<string, OUT> = {
-        body: route.response,
+        body,
         statusCode: route.status,
         headers: {
           ...route.headers,


### PR DESCRIPTION
When stubbing an endpoint, we can now provide a `fixtureBuilder` function (instead of a `fixture` object).
The function takes the HTTP request as parameter, so that we can return a parametrized response (for example based on a query parameter or on the payload's content).

Example app and its tests have been updated.

Documentation has been updated.